### PR TITLE
Implement detect restriction level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,7 @@ pub use tables::UNICODE_VERSION;
 
 pub mod mixed_script;
 pub mod general_security_profile;
+pub mod restriction_level;
 
 pub use mixed_script::MixedScript;
 pub use general_security_profile::GeneralSecurityProfile;

--- a/src/mixed_script.rs
+++ b/src/mixed_script.rs
@@ -5,6 +5,7 @@ use unicode_script::{Script, ScriptExtension};
 /// An Augmented script set, as defined by UTS 39
 ///
 /// https://www.unicode.org/reports/tr39/#def-augmented-script-set
+#[derive(Copy, Clone, PartialEq, Debug, Hash)]
 pub struct AugmentedScriptSet {
     /// The base ScriptExtension value
     pub base: ScriptExtension,
@@ -106,6 +107,16 @@ impl AugmentedScriptSet {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+pub enum RestrictionLevel {
+    ASCIIOnly,
+    SingleScript,
+    HighlyRestrictive,
+    ModeratelyRestrictive,
+    MinimallyRestrictive,
+    Unrestricted,
+}
+
 /// Extension trait for [mixed-script detection](https://www.unicode.org/reports/tr39/#Mixed_Script_Detection)
 pub trait MixedScript {
     /// Check if a string is [single-script](https://www.unicode.org/reports/tr39/#def-single-script)
@@ -115,6 +126,9 @@ pub trait MixedScript {
 
     /// Find the [resolved script set](https://www.unicode.org/reports/tr39/#def-resolved-script-set) of a given string
     fn resolve_script_set(self) -> AugmentedScriptSet;
+
+    /// Detect the [restriction level](https://www.unicode.org/reports/tr39/#Restriction_Level_Detection) of a given string
+    fn detect_restriction_level(self) -> RestrictionLevel;
 }
 
 impl MixedScript for &'_ str {
@@ -124,5 +138,37 @@ impl MixedScript for &'_ str {
 
     fn resolve_script_set(self) -> AugmentedScriptSet {
         self.into()
+    }
+
+    fn detect_restriction_level(self) -> RestrictionLevel {
+        use crate::GeneralSecurityProfile;
+        let mut ascii_only = true;
+        let mut set = AugmentedScriptSet::default();
+        let mut exclude_latin_set = AugmentedScriptSet::default();
+        for ch in self.chars() {
+            if !GeneralSecurityProfile::identifier_allowed(ch) {
+                return RestrictionLevel::Unrestricted;
+            }
+            if ch as u32 > 0x7F {
+                ascii_only = false;
+            }
+            let ch_set = ch.into();
+            set = set.intersect(ch_set);
+            if !ch_set.base.contains_script(Script::Latin) {
+                exclude_latin_set.intersect(ch_set);
+            }
+        }
+        if ascii_only {
+            return RestrictionLevel::ASCIIOnly;
+        } else if !set.is_empty() {
+            return RestrictionLevel::SingleScript;
+        } else if exclude_latin_set.kore || exclude_latin_set.hanb || exclude_latin_set.jpan {
+            return RestrictionLevel::HighlyRestrictive;
+        } else if let ScriptExtension::Single(script) = exclude_latin_set.base {
+            if script.is_recommended() && script != Script::Cyrillic && script != Script::Greek {
+                return RestrictionLevel::ModeratelyRestrictive;
+            }
+        }
+        return RestrictionLevel::MinimallyRestrictive;
     }
 }

--- a/src/restriction_level.rs
+++ b/src/restriction_level.rs
@@ -1,0 +1,75 @@
+//! For detecting the [restriction level](https://www.unicode.org/reports/tr39/#Restriction_Level_Detection)
+//! a string conforms to
+
+use crate::mixed_script::AugmentedScriptSet;
+use unicode_script::{Script, ScriptExtension};
+use crate::GeneralSecurityProfile;
+
+#[derive(Copy, Clone, PartialEq, PartialOrd, Eq, Ord, Debug, Hash)]
+/// The [Restriction level](https://www.unicode.org/reports/tr39/#Restriction_Level_Detection)
+/// a string conforms to
+pub enum RestrictionLevel {
+    /// https://www.unicode.org/reports/tr39/#ascii_only
+    ASCIIOnly,
+    /// https://www.unicode.org/reports/tr39/#single_script
+    SingleScript,
+    /// https://www.unicode.org/reports/tr39/#highly_restrictive
+    HighlyRestrictive,
+    /// https://www.unicode.org/reports/tr39/#moderately_restrictive
+    ModeratelyRestrictive,
+    /// https://www.unicode.org/reports/tr39/#minimally_restrictive
+    MinimallyRestrictive,
+    /// https://www.unicode.org/reports/tr39/#unrestricted
+    Unrestricted,
+}
+
+/// Utilities for determining which [restriction level](https://www.unicode.org/reports/tr39/#Restriction_Level_Detection)
+/// a string satisfies 
+pub trait RestrictionLevelDetection: Sized {
+    /// Detect the [restriction level](https://www.unicode.org/reports/tr39/#Restriction_Level_Detection)
+    ///
+    /// This will _not_ check identifier well-formedness, as different applications may have different notions of well-formedness
+    fn detect_restriction_level(self) -> RestrictionLevel;
+
+
+    /// Check if a string satisfies the supplied [restriction level](https://www.unicode.org/reports/tr39/#Restriction_Level_Detection)
+    ///
+    /// This will _not_ check identifier well-formedness, as different applications may have different notions of well-formedness
+    fn check_restriction_level(self, level: RestrictionLevel) -> bool {
+        self.detect_restriction_level() <= level
+    }
+}
+
+impl RestrictionLevelDetection for &'_ str {
+    fn detect_restriction_level(self) -> RestrictionLevel {
+        let mut ascii_only = true;
+        let mut set = AugmentedScriptSet::default();
+        let mut exclude_latin_set = AugmentedScriptSet::default();
+        for ch in self.chars() {
+            if !GeneralSecurityProfile::identifier_allowed(ch) {
+                return RestrictionLevel::Unrestricted;
+            }
+            if ch.is_ascii() {
+                ascii_only = false;
+            }
+            let ch_set = ch.into();
+            set.intersect_with(ch_set);
+            if !ch_set.base.contains_script(Script::Latin) {
+                exclude_latin_set.intersect_with(ch_set);
+            }
+        }
+
+        if ascii_only {
+            return RestrictionLevel::ASCIIOnly;
+        } else if !set.is_empty() {
+            return RestrictionLevel::SingleScript;
+        } else if exclude_latin_set.kore || exclude_latin_set.hanb || exclude_latin_set.jpan {
+            return RestrictionLevel::HighlyRestrictive;
+        } else if let ScriptExtension::Single(script) = exclude_latin_set.base {
+            if script.is_recommended() && script != Script::Cyrillic && script != Script::Greek {
+                return RestrictionLevel::ModeratelyRestrictive;
+            }
+        }
+        return RestrictionLevel::MinimallyRestrictive;
+    }
+}


### PR DESCRIPTION
This is a draft implementation. I implemented the algorithm itself, however there's a `Recommended` script concept which is defined in TR31.  For now this `is_recommended()` method is not defined.