### PR TITLE
Change file download urls to pull from https

### DIFF
--- a/scripts/unicode.py
+++ b/scripts/unicode.py
@@ -46,7 +46,7 @@ UNICODE_VERSION_NUMBER = "%s.%s.%s" %UNICODE_VERSION
 # Download a Unicode security table file
 def fetch(f):
     if not os.path.exists(os.path.basename(f)):
-        os.system("curl -O http://www.unicode.org/Public/security/%s/%s"
+        os.system("curl -O https://www.unicode.org/Public/security/%s/%s"
                   % (UNICODE_VERSION_NUMBER, f))
 
     if not os.path.exists(os.path.basename(f)):
@@ -56,7 +56,7 @@ def fetch(f):
 # Download a UCD table file
 def fetch_unidata(f):
     if not os.path.exists(os.path.basename(f)):
-        os.system("curl -O http://www.unicode.org/Public/%s/ucd/%s"
+        os.system("curl -O https://www.unicode.org/Public/%s/ucd/%s"
                   % (UNICODE_VERSION_NUMBER, f))
 
     if not os.path.exists(os.path.basename(f)):


### PR DESCRIPTION
I was reading this over to understand how rust uses the unicode data files, and how rust handles these sort of unicode security issues, and I noticed that when it downloads the source files, the urls it's curling aren't https:

https://github.com/unicode-rs/unicode-security/blob/f42826a74411b66d3a1205545e9d8efdc6e8686d/scripts/unicode.py#L46-L64

Of course this is in a script that runs pre-commit, and for that + likely many other reasons that I'm ignorant of, this PR may not be needed.

Btw thanks for all you're doing in this repo/crate. This code + its comments are the only thing that's helping me see how one can go from 'tc39 provided files' to 'prevent/warn of naughtiness in source code'. 🙏